### PR TITLE
Fix BigQuery read worker queue handling

### DIFF
--- a/src/pyarrow/bigquery/read.py
+++ b/src/pyarrow/bigquery/read.py
@@ -4,8 +4,10 @@ import datetime
 import inspect
 import logging
 import multiprocessing
+import queue
 import threading
 import time
+import traceback
 
 from google.cloud import bigquery, bigquery_storage
 from google.cloud.exceptions import NotFound
@@ -21,6 +23,32 @@ PYARROW_COMPRESSIONS = {
 }
 
 logger = logging.getLogger(__name__)
+
+_QUEUE_RESULT = "result"
+_QUEUE_DONE = "done"
+_QUEUE_ERROR = "error"
+_QUEUE_GET_TIMEOUT = 0.25
+_WORKER_JOIN_TIMEOUT = 5.0
+
+
+def _queue_result(key: str):
+    return (_QUEUE_RESULT, key)
+
+
+def _queue_error(exc: BaseException):
+    return (_QUEUE_ERROR, (type(exc).__name__, str(exc), traceback.format_exc()))
+
+
+def _close_client_transport(client):
+    if not client:
+        return
+    transport = getattr(client, "transport", None)
+    close = getattr(transport, "close", None)
+    if close:
+        try:
+            close()
+        except Exception:
+            logger.exception("Failed to close BigQuery Storage client transport")
 
 
 def _bq_table_exists(project: str, location: str):
@@ -75,31 +103,37 @@ def _stream_worker(
     queue_results: multiprocessing.Queue,
     ipc_exchange,
 ):
-    read_client = bigquery_storage.BigQueryReadClient()
-    batches = []
-    for stream in read_streams:
-        t = time.time()
+    read_client = None
+    try:
+        read_client = bigquery_storage.BigQueryReadClient()
+        batches = []
+        for stream in read_streams:
+            t = time.time()
 
-        for message in read_client.read_rows(stream):
-            record_batch = pa.ipc.read_record_batch(
-                message.arrow_record_batch.serialized_record_batch,
-                table_schema,
-            )
+            for message in read_client.read_rows(stream):
+                record_batch = pa.ipc.read_record_batch(
+                    message.arrow_record_batch.serialized_record_batch,
+                    table_schema,
+                )
 
-            batches.append(record_batch)
+                batches.append(record_batch)
 
-            while batches and sum(b.num_rows for b in batches) >= batch_size:
-                table = pa.Table.from_batches(batches)
-                queue_results.put(ipc_exchange.store(table[:batch_size]))
-                batches = table[batch_size:].to_batches()
+                while batches and sum(b.num_rows for b in batches) >= batch_size:
+                    table = pa.Table.from_batches(batches)
+                    queue_results.put(_queue_result(ipc_exchange.store(table[:batch_size])))
+                    batches = table[batch_size:].to_batches()
 
-        logger.debug(f"Stream {stream} done in {time.time() - t:.2f} seconds")
+            logger.debug(f"Stream {stream} done in {time.time() - t:.2f} seconds")
 
-    if batches:
-        queue_key = ipc_exchange.store(pa.Table.from_batches(batches))
-        queue_results.put(queue_key)
+        if batches:
+            queue_key = ipc_exchange.store(pa.Table.from_batches(batches))
+            queue_results.put(_queue_result(queue_key))
 
-    queue_results.put(None)
+        queue_results.put((_QUEUE_DONE, None))
+    except BaseException as exc:
+        queue_results.put(_queue_error(exc))
+    finally:
+        _close_client_transport(read_client)
 
 
 class reader:
@@ -123,6 +157,12 @@ class reader:
         self.worker_type = worker_type
         self.batch_size = batch_size
 
+        if self.worker_type not in (threading.Thread, multiprocessing.Process):
+            raise ValueError(
+                f"Unsupported worker type {worker_type}, "
+                f"expected threading.Thread or multiprocessing.Process"
+            )
+
         # COMPRESSIONS
         assert compression in PYARROW_COMPRESSIONS, (
             f"Compression {compression} not supported, "
@@ -136,11 +176,6 @@ class reader:
                 ipc_exchange = exchange.Memory()
             elif worker_type == multiprocessing.Process:
                 ipc_exchange = exchange.Feather()
-            else:
-                raise ValueError(
-                    f"Unsupported worker type {worker_type}, "
-                    f"expected threading.Thread or multiprocessing.Process"
-                )
 
         if inspect.isclass(ipc_exchange):
             raise TypeError(
@@ -181,22 +216,27 @@ class reader:
 
     def __enter__(self):
         self.t0 = time.time()
-        self.manager = multiprocessing.Manager()
-        self.queue_results = self.manager.Queue()
+        if self.worker_type == threading.Thread:
+            self.queue_results = queue.Queue()
+        else:
+            self.queue_results = multiprocessing.Queue()
         self.read_client = bigquery_storage.BigQueryReadClient()
         self.workers = []
 
         _bq_table_exists(self.project, self.source)
 
-        self.streams, self.schema = _bq_read_create_strems(
-            read_client=self.read_client,
-            parent=self.project,
-            source=self.source,
-            selected_fields=self.columns,
-            row_restrictions=self.row_restrictions,
-            max_stream_count=self.worker_count * 3,
-            compression=self.compression,
-        )
+        try:
+            self.streams, self.schema = _bq_read_create_strems(
+                read_client=self.read_client,
+                parent=self.project,
+                source=self.source,
+                selected_fields=self.columns,
+                row_restrictions=self.row_restrictions,
+                max_stream_count=self.worker_count * 3,
+                compression=self.compression,
+            )
+        finally:
+            _close_client_transport(self.read_client)
 
         self.workers_done = 0
 
@@ -220,30 +260,85 @@ class reader:
                     self.ipc_exchange,
                 ),
             )
+            if self.worker_type == threading.Thread:
+                worker.daemon = True
             worker.start()
             self.workers.append(worker)
 
         return self
 
-    def __exit__(self, *_, **__):
+    def __exit__(self, exc_type, *_):
         for w in self.workers:
-            w.join()
+            w.join(timeout=_WORKER_JOIN_TIMEOUT)
+
+        alive_workers = [w for w in self.workers if w.is_alive()]
+        for worker in alive_workers:
+            terminate = getattr(worker, "terminate", None)
+            if terminate:
+                terminate()
+
+        for worker in alive_workers:
+            if getattr(worker, "terminate", None):
+                worker.join(timeout=_WORKER_JOIN_TIMEOUT)
+
+        still_alive = [w for w in self.workers if w.is_alive()]
+        if still_alive:
+            message = f"{len(still_alive)} BigQuery read worker(s) did not stop cleanly"
+            logger.error(message)
+            if exc_type is None:
+                raise RuntimeError(message)
 
         logger.debug(f"Time taken: {time.time() - self.t0:.2f}")
 
     def __iter__(self):
         return self
 
-    def __next__(self):
-        element = self.queue_results.get()
-        if not element:
+    def _process_queue_message(self, kind: str, payload):
+        if kind == _QUEUE_DONE:
             self.workers_done += 1
             if self.workers_done == self.actual_worker_count:
+                return None
+            return "continue"
+
+        if kind == _QUEUE_ERROR:
+            error_type, error_message, formatted_traceback = payload
+            raise RuntimeError(
+                f"BigQuery read worker failed with {error_type}: {error_message}\n"
+                f"{formatted_traceback}"
+            )
+
+        if kind == _QUEUE_RESULT:
+            return payload
+
+        raise RuntimeError(f"Unexpected BigQuery read worker message: {(kind, payload)!r}")
+
+    def __next__(self):
+        while True:
+            try:
+                element = self.queue_results.get(timeout=_QUEUE_GET_TIMEOUT)
+            except queue.Empty:
+                self._raise_if_workers_failed()
+                continue
+
+            kind, payload = element
+            result = self._process_queue_message(kind, payload)
+            if result == "continue":
+                continue
+            if result is None:
                 raise StopIteration
-            else:
-                return self.__next__()
-        else:
-            return self.ipc_exchange.load(element)
+            return self.ipc_exchange.load(result)
+
+    def _raise_if_workers_failed(self):
+        for idx, worker in enumerate(self.workers):
+            exitcode = getattr(worker, "exitcode", None)
+            if exitcode not in (None, 0):
+                raise RuntimeError(f"BigQuery read worker {idx} exited with code {exitcode}")
+
+        if self.workers_done < self.actual_worker_count and self.workers:
+            if all(not worker.is_alive() for worker in self.workers):
+                raise RuntimeError(
+                    "BigQuery read workers exited before signaling completion"
+                )
 
 
 def reader_query(

--- a/tests/unit/test_read_workers.py
+++ b/tests/unit/test_read_workers.py
@@ -1,0 +1,59 @@
+import importlib
+
+import pyarrow as pa
+import pytest
+
+
+def test_thread_reader_uses_thread_queue_without_manager(monkeypatch):
+    read_mod = importlib.import_module("pyarrow.bigquery.read")
+
+    def fail_manager():
+        raise AssertionError("multiprocessing.Manager should not be used in thread mode")
+
+    class FakeReadClient:
+        pass
+
+    def fake_stream_worker(read_streams, table_schema, batch_size, queue_results, ipc_exchange):
+        table = pa.table({"x": [1]})
+        queue_results.put(read_mod._queue_result(ipc_exchange.store(table)))
+        queue_results.put((read_mod._QUEUE_DONE, None))
+
+    monkeypatch.setattr(read_mod.multiprocessing, "Manager", fail_manager)
+    monkeypatch.setattr(read_mod.bigquery_storage, "BigQueryReadClient", FakeReadClient)
+    monkeypatch.setattr(read_mod, "_bq_table_exists", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        read_mod,
+        "_bq_read_create_strems",
+        lambda **kwargs: (["stream-1"], pa.schema([("x", pa.int64())])),
+    )
+    monkeypatch.setattr(read_mod, "_stream_worker", fake_stream_worker)
+
+    with read_mod.reader("project.dataset.table", worker_count=1) as r:
+        assert next(r).to_pydict() == {"x": [1]}
+        with pytest.raises(StopIteration):
+            next(r)
+
+
+def test_stream_worker_reports_errors(monkeypatch):
+    read_mod = importlib.import_module("pyarrow.bigquery.read")
+
+    class FailingReadClient:
+        def read_rows(self, stream):
+            raise RuntimeError(f"failed to read {stream}")
+
+    monkeypatch.setattr(read_mod.bigquery_storage, "BigQueryReadClient", FailingReadClient)
+
+    queue_results = read_mod.queue.Queue()
+    read_mod._stream_worker(
+        ["stream-1"],
+        pa.schema([("x", pa.int64())]),
+        100,
+        queue_results,
+        read_mod.exchange.Memory(),
+    )
+
+    kind, payload = queue_results.get(timeout=1)
+
+    assert kind == read_mod._QUEUE_ERROR
+    assert payload[0] == "RuntimeError"
+    assert "failed to read stream-1" in payload[1]


### PR DESCRIPTION
## Summary
- Use thread-local queues for thread workers and multiprocessing queues for process workers.
- Send typed worker queue messages so worker errors propagate instead of hanging iteration.
- Close BigQuery Storage transports and bound worker joins to avoid stuck process cleanup.

## Test plan
- `uv run pytest tests/unit/test_read_workers.py -q`
- `uv run pytest tests/unit/ -q`