### PR TITLE
Default process reads to Arrow IPC

### DIFF
--- a/src/pyarrow/bigquery/exchange/__init__.py
+++ b/src/pyarrow/bigquery/exchange/__init__.py
@@ -1,6 +1,16 @@
-from .base import ConcurrencyCompatible  # noqa: F401
+from .base import ConcurrencyCompatible
+from .shared_memory import SharedMemory
+from .feather import Feather
+from .arrow_ipc import ArrowIpc
+from .memory import Memory
+from .shared_dict import SharedMemoryDict
 
-from .shared_memory import SharedMemory  # noqa
-from .feather import Feather  # noqa: F401
-from .memory import Memory  # noqa: F401
-from .shared_dict import SharedMemoryDict  # noqa: F401
+
+__all__ = [
+    "ConcurrencyCompatible",
+    "SharedMemory",
+    "Feather",
+    "ArrowIpc",
+    "Memory",
+    "SharedMemoryDict",
+]

--- a/src/pyarrow/bigquery/exchange/arrow_ipc.py
+++ b/src/pyarrow/bigquery/exchange/arrow_ipc.py
@@ -1,0 +1,40 @@
+import os
+import tempfile
+import weakref
+
+import pyarrow as pa
+
+from .base import ConcurrencyCompatible
+
+PREFIX = "pyarrow-bigquery-ipc-"
+
+
+def _unlink(path: str) -> None:
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
+
+
+class ArrowIpc(ConcurrencyCompatible):
+    """Transfer tables between processes via Arrow IPC files (memory-mapped on load)."""
+
+    thread_compatible = True
+    process_compatible = True
+
+    def store(self, table: pa.Table) -> str:
+        fd, file_name = tempfile.mkstemp(prefix=PREFIX, suffix=".arrow")
+        os.close(fd)
+
+        with pa.OSFile(file_name, "wb") as sink:
+            with pa.ipc.new_file(sink, table.schema) as writer:
+                writer.write_table(table)
+
+        return file_name
+
+    def load(self, key: str) -> pa.Table:
+        with pa.memory_map(key, "r") as source:
+            with pa.ipc.open_file(source) as reader:
+                table = reader.read_all()
+        weakref.finalize(table, _unlink, key)
+        return table

--- a/src/pyarrow/bigquery/exchange/feather.py
+++ b/src/pyarrow/bigquery/exchange/feather.py
@@ -1,7 +1,8 @@
 import os
 import tempfile
+import weakref
+
 import pyarrow as pa
-import threading
 import pyarrow.feather as fa
 
 from .base import ConcurrencyCompatible
@@ -9,12 +10,20 @@ from .base import ConcurrencyCompatible
 PREFIX = "pyarrow-bigquery-"
 
 
+def _unlink(path: str) -> None:
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
+
+
 class Feather(ConcurrencyCompatible):
     thread_compatible = True
     process_compatible = True
 
     def store(self, table: pa.Table) -> str:
-        _, file_name = tempfile.mkstemp(prefix=PREFIX)
+        fd, file_name = tempfile.mkstemp(prefix=PREFIX)
+        os.close(fd)
 
         with open(file_name, "wb") as f:
             fa.write_feather(table, f)
@@ -22,7 +31,6 @@ class Feather(ConcurrencyCompatible):
         return file_name
 
     def load(self, key: str) -> pa.Table:
-        with open(key, "rb") as f:
-            table = fa.read_table(f)
-            threading.Thread(target=os.unlink, args=(key,)).start()
-            return table
+        table = fa.read_table(key, memory_map=True)
+        weakref.finalize(table, _unlink, key)
+        return table

--- a/src/pyarrow/bigquery/exchange/shared_memory.py
+++ b/src/pyarrow/bigquery/exchange/shared_memory.py
@@ -3,45 +3,36 @@ from __future__ import annotations
 import sys
 import uuid
 
-from multiprocessing import shared_memory
-from multiprocessing import resource_tracker
+from multiprocessing import resource_tracker, shared_memory
 
 import pyarrow as pa  # type: ignore[import]
 
-
 from .base import ConcurrencyCompatible
 
+PREFIX = "pyarrow_bq_"
 
-class _ReadBufferWrapper:
-    def __init__(self, shm: shared_memory.SharedMemory):
-        self._shm = shm
-        self._count = 0
 
-    def __buffer__(self, _) -> memoryview:
-        self._count += 1
-        return self._shm.buf
-
-    def __release_buffer__(self, view):
-        self._count -= 1
-        if self._count == 0:
-            self._shm.close()
-            self._shm.unlink()
-
-    def __del__(self):
-        try:
-            self._shm.close()
-            self._shm.unlink()
-        except FileNotFoundError:
-            pass
+def _parse_key(key: str) -> tuple[str, int]:
+    name, sep, size_str = key.partition(":")
+    if not sep:
+        raise ValueError(f"Invalid shared memory key {key!r}, expected 'name:size'")
+    return name, int(size_str)
 
 
 class SharedMemory(ConcurrencyCompatible):
+    """Transfer tables between processes via named shared memory segments.
+
+    Keys passed through the read queue are ``{segment_name}:{byte_length}``.
+    The main process copies bytes out and unlinks the segment immediately on
+    load so /dev/shm does not accumulate while batches wait in the queue.
+    """
+
     thread_compatible = False
     process_compatible = True
 
     def __init__(self):
-        if sys.version_info <= (3, 12):
-            raise RuntimeError("Shared memory IPC requires Python 3.12 or later.")
+        if sys.version_info < (3, 8):
+            raise RuntimeError("Shared memory IPC requires Python 3.8 or later.")
 
     def store(self, table: pa.Table) -> str:  # type: ignore
         sink = pa.BufferOutputStream()  # type: ignore
@@ -50,21 +41,31 @@ class SharedMemory(ConcurrencyCompatible):
             writer.write_table(table)
 
         data = sink.getvalue().to_pybytes()
+        nbytes = len(data)
 
-        key = uuid.uuid4().hex[:16]
+        name = f"{PREFIX}{uuid.uuid4().hex[:16]}"
         shm = shared_memory.SharedMemory(
             create=True,
-            size=len(data),
-            name=key,
+            size=nbytes,
+            name=name,
         )
         resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore
-        shm.buf[: len(data)] = data
+        shm.buf[:nbytes] = data
         shm.close()
 
-        return key
+        return f"{name}:{nbytes}"
 
     def load(self, key: str) -> pa.Table:  # type: ignore
-        shm = shared_memory.SharedMemory(name=key)
-        resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore
+        name, nbytes = _parse_key(key)
+        shm = shared_memory.SharedMemory(name=name)
 
-        return pa.ipc.open_stream(pa.py_buffer(_ReadBufferWrapper(shm))).read_all()  # type: ignore
+        try:
+            data = bytes(shm.buf[:nbytes])
+        finally:
+            shm.close()
+            try:
+                shm.unlink()
+            except FileNotFoundError:
+                pass
+
+        return pa.ipc.open_stream(pa.py_buffer(data)).read_all()  # type: ignore

--- a/src/pyarrow/bigquery/read.py
+++ b/src/pyarrow/bigquery/read.py
@@ -135,7 +135,7 @@ class reader:
             if worker_type == threading.Thread:
                 ipc_exchange = exchange.Memory()
             elif worker_type == multiprocessing.Process:
-                ipc_exchange = exchange.Feather()
+                ipc_exchange = exchange.ArrowIpc()
             else:
                 raise ValueError(
                     f"Unsupported worker type {worker_type}, "
@@ -182,7 +182,11 @@ class reader:
     def __enter__(self):
         self.t0 = time.time()
         self.manager = multiprocessing.Manager()
-        self.queue_results = self.manager.Queue()
+        queue_maxsize = 0
+        if type(self.ipc_exchange) is exchange.SharedMemory:
+            # Limit in-flight shm segments while the main process drains the queue.
+            queue_maxsize = max(4, self.worker_count * 2)
+        self.queue_results = self.manager.Queue(maxsize=queue_maxsize)
         self.read_client = bigquery_storage.BigQueryReadClient()
         self.workers = []
 

--- a/tests/unit/test_arrow_ipc_exchange.py
+++ b/tests/unit/test_arrow_ipc_exchange.py
@@ -1,0 +1,11 @@
+import pyarrow as pa
+
+from pyarrow.bigquery.exchange.arrow_ipc import ArrowIpc
+
+
+def test_arrow_ipc_roundtrip():
+    exchange = ArrowIpc()
+    original = pa.table({"x": [1, 2, 3], "y": ["a", "b", "c"]})
+    key = exchange.store(original)
+    loaded = exchange.load(key)
+    assert loaded.equals(original)

--- a/tests/unit/test_feather_exchange.py
+++ b/tests/unit/test_feather_exchange.py
@@ -1,0 +1,20 @@
+import gc
+import os
+
+import pyarrow as pa
+
+from pyarrow.bigquery.exchange.feather import Feather
+
+
+def test_feather_load_memory_maps_and_unlinks_after_table_is_released():
+    exchange = Feather()
+    original = pa.table({"x": list(range(10_000))})
+    key = exchange.store(original)
+
+    loaded = exchange.load(key)
+    assert loaded.num_rows == original.num_rows
+    assert os.path.exists(key)
+
+    del loaded
+    gc.collect()
+    assert not os.path.exists(key)

--- a/tests/unit/test_ipc_defaults.py
+++ b/tests/unit/test_ipc_defaults.py
@@ -1,0 +1,15 @@
+import multiprocessing
+import threading
+
+from pyarrow.bigquery import exchange
+from pyarrow.bigquery.read import reader
+
+
+def test_process_default_ipc_is_arrow_ipc():
+    r = reader("project.dataset.table", worker_type=multiprocessing.Process)
+    assert isinstance(r.ipc_exchange, exchange.ArrowIpc)
+
+
+def test_thread_default_ipc_is_memory():
+    r = reader("project.dataset.table", worker_type=threading.Thread)
+    assert isinstance(r.ipc_exchange, exchange.Memory)

--- a/tests/unit/test_shared_memory_exchange.py
+++ b/tests/unit/test_shared_memory_exchange.py
@@ -1,0 +1,37 @@
+import multiprocessing as mp
+import os
+
+import pyarrow as pa
+
+from pyarrow.bigquery.exchange.shared_memory import SharedMemory, _parse_key
+
+
+def _worker_store(queue: mp.Queue, num_rows: int) -> None:
+    exchange = SharedMemory()
+    table = pa.table({"x": list(range(num_rows))})
+    queue.put(exchange.store(table))
+
+
+def test_shared_memory_roundtrip_in_process():
+    queue: mp.Queue = mp.Queue()
+    process = mp.Process(target=_worker_store, args=(queue, 1000))
+    process.start()
+    process.join()
+    assert process.exitcode == 0
+
+    key = queue.get()
+    assert ":" in key
+
+    exchange = SharedMemory()
+    loaded = exchange.load(key)
+    assert loaded.num_rows == 1000
+
+
+def test_shared_memory_load_unlinks_segment():
+    exchange = SharedMemory()
+    key = exchange.store(pa.table({"x": [1, 2, 3]}))
+    name, _ = _parse_key(key)
+    assert os.path.exists(f"/dev/shm/{name}")
+
+    exchange.load(key)
+    assert not os.path.exists(f"/dev/shm/{name}")


### PR DESCRIPTION
## Summary
- Add a file-backed Arrow IPC exchange and make it the default for process workers.
- Improve Feather cleanup by closing `mkstemp` descriptors, memory-mapping reads, and unlinking temp files with table lifetime.
- Repair SharedMemory keys/loading so segments are copied out, unlinked promptly, and bounded in-flight for process reads.

## Test plan
- `uv run pytest tests/unit/test_arrow_ipc_exchange.py tests/unit/test_feather_exchange.py tests/unit/test_ipc_defaults.py tests/unit/test_shared_memory_exchange.py -q`
- `uv run pytest tests/unit/ -q`

Note: this is independent from #5 so it can target `master`; the two PRs will touch nearby read-worker setup code and may need a small conflict resolution depending on merge order.